### PR TITLE
Fixes

### DIFF
--- a/allure-generator/src/main/javascript/plugins/tab-groups/index.js
+++ b/allure-generator/src/main/javascript/plugins/tab-groups/index.js
@@ -2,22 +2,36 @@
 
 allure.api.addTranslation('en', {
     tab: {
-        groups: {
-            name: 'Groups'
+        scenarioGroups: {
+            name: 'Scenario Groups'
         }
     }
 });
 
-allure.api.addTab('groups', {
-    title: 'tab.groups.name',
-    icon: 'fa fa-list',
-    route: 'groups(/)(:testGroup)(/)(:testResult)(/)(:testResultTab)(/)',
-    onEnter: (testGroup, testResult, testResultTab) => new allure.components.TreeLayout({
-        testGroup,
-        testResult,
-        testResultTab,
-        tabName: 'tab.groups.name',
-        baseUrl: 'groups',
-        url: 'data/groups.json'
-    })
+allure.api.addTranslation('en', {
+    tab: {
+        storyGroups: {
+            name: 'Story Groups'
+        }
+    }
 });
+
+addTab('storyGroups', 'groups.json');
+addTab('scenarioGroups', 'scenarioGroups.json');
+
+function addTab(tabName, dataPath) {
+    const nameKey = 'tab.' + tabName + '.name';
+    allure.api.addTab(tabName, {
+        title: nameKey,
+        icon: 'fa fa-list',
+        route: tabName + '(/)(:testGroup)(/)(:testResult)(/)(:testResultTab)(/)',
+        onEnter: (testGroup, testResult, testResultTab) => new allure.components.TreeLayout({
+            testGroup,
+            testResult,
+            testResultTab,
+            tabName: nameKey,
+            baseUrl: tabName,
+            url: 'data/' + dataPath
+        })
+    });
+}

--- a/allure-plugin-api/src/main/java/io/qameta/allure/tree/TreeUtils.java
+++ b/allure-plugin-api/src/main/java/io/qameta/allure/tree/TreeUtils.java
@@ -47,7 +47,12 @@ public final class TreeUtils {
 
     public static List<TreeLayer> groupByLabels(final TestResult testResult,
                                                 final LabelName... labelNames) {
-        return Stream.of(labelNames)
+        return groupByLabels(testResult, Stream.of(labelNames).map(LabelName::value));
+    }
+
+    public static List<TreeLayer> groupByLabels(final TestResult testResult,
+                                                final Stream<String> labelNames) {
+        return labelNames
                 .map(testResult::findAllLabels)
                 .filter(strings -> !strings.isEmpty())
                 .map(DefaultTreeLayer::new)

--- a/allure-plugin-api/src/test/java/io/qameta/allure/tree/TestResultTreeTest.java
+++ b/allure-plugin-api/src/test/java/io/qameta/allure/tree/TestResultTreeTest.java
@@ -18,8 +18,12 @@ package io.qameta.allure.tree;
 import io.qameta.allure.entity.Label;
 import io.qameta.allure.entity.TestResult;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collections;
+import java.util.stream.Stream;
 
 import static io.qameta.allure.entity.LabelName.FEATURE;
 import static io.qameta.allure.entity.LabelName.STORY;
@@ -43,11 +47,20 @@ class TestResultTreeTest {
                 .hasSize(0);
     }
 
-    @Test
-    void shouldCrossGroup() {
+    static Stream<Arguments> testResults()
+    {
+        return Stream.of(
+                Arguments.of((TreeClassifier<TestResult>) testResult -> groupByLabels(testResult, FEATURE, STORY)),
+                Arguments.of((TreeClassifier<TestResult>) testResult -> groupByLabels(testResult, Stream.of(FEATURE.value(), STORY.value())))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testResults")
+    void shouldCrossGroup(final TreeClassifier<TestResult> treeClassifier) {
         final Tree<TestResult> behaviors = new TestResultTree(
                 "behaviors",
-                testResult -> groupByLabels(testResult, FEATURE, STORY)
+                treeClassifier
         );
 
         final TestResult first = new TestResult()


### PR DESCRIPTION
* Separate Groups tab to Story Groups and Scenario Groups
* Expand API by adding io.qameta.allure.tree.TreeUtils.groupByLabels(TestResult,Stream<String>)